### PR TITLE
Check for the presense of body in the raw_response before casting to string

### DIFF
--- a/lib/motion/oauth2.rb
+++ b/lib/motion/oauth2.rb
@@ -52,6 +52,7 @@ module Motion
       options[:headers].merge!(
         Authorization: "#{schema} #{access_token}"
       )
+      options.delete :files if options[:files].nil?
       options
     end
   end

--- a/lib/motion/oauth2/response.rb
+++ b/lib/motion/oauth2/response.rb
@@ -52,7 +52,7 @@ module Motion
       end
 
       def body
-        raw_response.body.to_str
+        raw_response.body.to_str unless raw_response.body.nil?
       end
 
       def json


### PR DESCRIPTION
For status 204 (success without content) the app would crash since it blindly casts the body of the raw_response to a string. I made a check for the presence of the body in the response before casting it to a string.
